### PR TITLE
Update FROM line in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/reference/builder/ for configuration references.
 # See https://docs.docker.com/#installation-guides for Docker installation.
 
-FROM google/appengine-python27
+FROM gcr.io/google_appengine/python-compat
 MAINTAINER Arkadii Yakovets <arcadiy@google.com>
 
 # Copy packages file.


### PR DESCRIPTION
Hey,

We've moved these base images to the Google Container Registry. They're now available publicly using the standard "docker pull" commands and the setup-managed-vms command has been removed.
